### PR TITLE
[FEAT] Add instructions to ready screen

### DIFF
--- a/src/components/Balances.tsx
+++ b/src/components/Balances.tsx
@@ -26,7 +26,7 @@ export const Balances: React.FC<Props> = ({
 
   return (
     <>
-      <div className="flex flex-col absolute space-y-1 items-end z-50 right-3 top-3 !text-[28px] text-stroke">
+      <div className="flex flex-col absolute space-y-1 items-end z-50 right-3 top-3 !text-[28px] text-stroke pointer-events-none">
         <div
           className="flex cursor-pointer items-center space-x-3 relative"
           onClick={onClick}

--- a/src/features/portal/examples/chickenRescue/components/ChickenRescueHUD.tsx
+++ b/src/features/portal/examples/chickenRescue/components/ChickenRescueHUD.tsx
@@ -1,5 +1,5 @@
 import React, { useContext } from "react";
-import { useActor } from "@xstate/react";
+import { useSelector } from "@xstate/react";
 import { PortalContext } from "../lib/PortalProvider";
 import { PIXEL_SCALE } from "features/game/lib/constants";
 import { SUNNYSIDE } from "assets/sunnyside";
@@ -9,102 +9,109 @@ import { HudContainer } from "components/ui/HudContainer";
 import { Balances } from "components/Balances";
 import Decimal from "decimal.js-light";
 import { Label } from "components/ui/Label";
+import { t } from "i18next";
+import { isTouchDevice } from "features/world/lib/device";
+import { PortalMachineState } from "../lib/chickenRescueMachine";
+
+const _score = (state: PortalMachineState) => state.context.score;
+const _state = (state: PortalMachineState) => state.context.state;
+const _ready = (state: PortalMachineState) => state.matches("ready");
 
 export const ChickenRescueHUD: React.FC = () => {
   const { portalService } = useContext(PortalContext);
-  const [portalState] = useActor(portalService);
 
   const travelHome = () => {
     goHome();
   };
 
-  const { score, endAt, state } = portalState.context;
-
-  // const timer = useCountdown(endAt);
-
-  // const secondsLeft = !portalState.matches("playing")
-  //   ? GAME_SECONDS
-  //   : timer.seconds;
+  const state = useSelector(portalService, _state);
+  const score = useSelector(portalService, _score);
+  const ready = useSelector(portalService, _ready);
 
   const target = state.minigames.prizes["chicken-rescue"]?.score;
 
   return (
-    <>
-      <HudContainer>
-        <Balances
-          sfl={portalState.context.state.balance}
-          coins={portalState.context.state.coins}
-          blockBucks={
-            portalState.context.state.inventory["Block Buck"] ?? new Decimal(0)
-          }
-        />
-        <div className="absolute top-4 left-4">
-          {!!target && (
-            <Label icon={SUNNYSIDE.resource.chicken} type="vibrant">
-              {`Target: ${target}`}
-            </Label>
-          )}
-          <div className="relative ">
-            <div className="h-6 w-full bg-black opacity-30 absolute coins-bb-hud-backdrop-reverse" />
-            {/* Coins */}
-            <div
-              className="flex items-center space-x-2 z-10 absolute"
-              style={{
-                width: "120px",
-                paddingTop: "3px",
-                paddingLeft: "3px",
-              }}
-            >
-              <span className="balance-text">{`Score: ${score}`}</span>
-            </div>
-          </div>
-        </div>
-        {/* <InnerPanel className="absolute top-4 left-4">
-          <div className="flex items-center p-1">
-            <img src={SUNNYSIDE.icons.stopwatch} className="h-6 mr-1" />
-            <span className="text-sm">{`${secondsLeft} seconds`}</span>
-          </div>
-        </InnerPanel> */}
-        <div
-          className="fixed z-50 flex flex-col justify-between"
-          style={{
-            left: `${PIXEL_SCALE * 3}px`,
-            bottom: `${PIXEL_SCALE * 3}px`,
-            width: `${PIXEL_SCALE * 22}px`,
-          }}
-        >
+    <HudContainer>
+      <Balances
+        sfl={state.balance}
+        coins={state.coins}
+        blockBucks={state.inventory["Block Buck"] ?? new Decimal(0)}
+      />
+      <div className="absolute top-4 left-4 pointer-events-none">
+        {!!target && (
+          <Label icon={SUNNYSIDE.resource.chicken} type="vibrant">
+            {`Target: ${target}`}
+          </Label>
+        )}
+        <div className="relative ">
+          <div className="h-6 w-full bg-black opacity-30 absolute coins-bb-hud-backdrop-reverse" />
+          {/* Coins */}
           <div
-            id="deliveries"
-            className="flex relative z-50 justify-center cursor-pointer hover:img-highlight"
+            className="flex items-center space-x-2 z-10 absolute"
             style={{
-              width: `${PIXEL_SCALE * 22}px`,
-              height: `${PIXEL_SCALE * 23}px`,
-            }}
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              travelHome();
+              width: "120px",
+              paddingTop: "3px",
+              paddingLeft: "3px",
             }}
           >
-            <img
-              src={SUNNYSIDE.ui.round_button}
-              className="absolute"
-              style={{
-                width: `${PIXEL_SCALE * 22}px`,
-              }}
-            />
-            <img
-              src={worldIcon}
-              style={{
-                width: `${PIXEL_SCALE * 12}px`,
-                left: `${PIXEL_SCALE * 5}px`,
-                top: `${PIXEL_SCALE * 4}px`,
-              }}
-              className="absolute"
-            />
+            <span className="balance-text">{`Score: ${score}`}</span>
           </div>
         </div>
-      </HudContainer>
-    </>
+      </div>
+
+      {/* Travel icon */}
+      <div
+        className="fixed z-50 flex flex-col justify-between"
+        style={{
+          left: `${PIXEL_SCALE * 3}px`,
+          bottom: `${PIXEL_SCALE * 3}px`,
+          width: `${PIXEL_SCALE * 22}px`,
+        }}
+      >
+        <div
+          id="travel"
+          className="flex relative z-50 justify-center cursor-pointer hover:img-highlight"
+          style={{
+            width: `${PIXEL_SCALE * 22}px`,
+            height: `${PIXEL_SCALE * 23}px`,
+          }}
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            travelHome();
+          }}
+        >
+          <img
+            src={SUNNYSIDE.ui.round_button}
+            className="absolute"
+            style={{
+              width: `${PIXEL_SCALE * 22}px`,
+            }}
+          />
+          <img
+            src={worldIcon}
+            style={{
+              width: `${PIXEL_SCALE * 12}px`,
+              left: `${PIXEL_SCALE * 5}px`,
+              top: `${PIXEL_SCALE * 4}px`,
+            }}
+            className="absolute"
+          />
+        </div>
+      </div>
+
+      {ready && (
+        <div className="absolute w-full h-full pointer-events-none">
+          <div className="absolute w-full h-full bg-black opacity-50" />
+          <div className="flex items-center justify-center absolute inset-0">
+            <span className="text-white text-center">
+              {isTouchDevice()
+                ? t("minigame.swipeToMove")
+                : t("minigame.arrowKeysToMove")}
+            </span>
+          </div>
+        </div>
+      )}
+    </HudContainer>
   );
 };

--- a/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
+++ b/src/lib/i18n/dictionaries/chinese_simplifiedDictionary.ts
@@ -4505,6 +4505,8 @@ const greenhouse: Record<GreenhouseKeys, string> = {
 
 const minigame: Record<Minigame, string> = {
   "minigame.chickenRescue": ENGLISH_TERMS["minigame.chickenRescue"],
+  "minigame.swipeToMove": ENGLISH_TERMS["minigame.swipeToMove"],
+  "minigame.arrowKeysToMove": ENGLISH_TERMS["minigame.arrowKeysToMove"],
   "minigame.comingSoon": ENGLISH_TERMS["minigame.comingSoon"],
   "minigame.completed": ENGLISH_TERMS["minigame.completed"],
   "minigame.confirm": ENGLISH_TERMS["minigame.confirm"],

--- a/src/lib/i18n/dictionaries/englishDictionary.ts
+++ b/src/lib/i18n/dictionaries/englishDictionary.ts
@@ -5146,6 +5146,8 @@ const greenhouse: Record<GreenhouseKeys, string> = {
 
 const minigame: Record<Minigame, string> = {
   "minigame.chickenRescue": "Minigame - Chicken Rescue",
+  "minigame.swipeToMove": "Swipe to move around",
+  "minigame.arrowKeysToMove": "Use WASD or arrow keys to move around",
   "minigame.comingSoon": "Coming soon...",
   "minigame.completed": "Complete",
   "minigame.confirm": "Are you sure you want to spend ",

--- a/src/lib/i18n/dictionaries/frenchDictionary.ts
+++ b/src/lib/i18n/dictionaries/frenchDictionary.ts
@@ -5287,6 +5287,8 @@ const greenhouse: Record<GreenhouseKeys, string> = {
 
 const minigame: Record<Minigame, string> = {
   "minigame.chickenRescue": ENGLISH_TERMS["minigame.chickenRescue"],
+  "minigame.swipeToMove": ENGLISH_TERMS["minigame.swipeToMove"],
+  "minigame.arrowKeysToMove": ENGLISH_TERMS["minigame.arrowKeysToMove"],
   "minigame.comingSoon": ENGLISH_TERMS["minigame.comingSoon"],
   "minigame.completed": ENGLISH_TERMS["minigame.completed"],
   "minigame.confirm": ENGLISH_TERMS["minigame.confirm"],

--- a/src/lib/i18n/dictionaries/portugueseDictionary.ts
+++ b/src/lib/i18n/dictionaries/portugueseDictionary.ts
@@ -5157,6 +5157,8 @@ const greenhouse: Record<GreenhouseKeys, string> = {
 
 const minigame: Record<Minigame, string> = {
   "minigame.chickenRescue": ENGLISH_TERMS["minigame.chickenRescue"],
+  "minigame.swipeToMove": ENGLISH_TERMS["minigame.swipeToMove"],
+  "minigame.arrowKeysToMove": ENGLISH_TERMS["minigame.arrowKeysToMove"],
   "minigame.comingSoon": ENGLISH_TERMS["minigame.comingSoon"],
   "minigame.completed": ENGLISH_TERMS["minigame.completed"],
   "minigame.confirm": ENGLISH_TERMS["minigame.confirm"],

--- a/src/lib/i18n/dictionaries/turkishDictionary.ts
+++ b/src/lib/i18n/dictionaries/turkishDictionary.ts
@@ -5132,6 +5132,8 @@ const greenhouse: Record<GreenhouseKeys, string> = {
 
 const minigame: Record<Minigame, string> = {
   "minigame.chickenRescue": ENGLISH_TERMS["minigame.chickenRescue"],
+  "minigame.swipeToMove": ENGLISH_TERMS["minigame.swipeToMove"],
+  "minigame.arrowKeysToMove": ENGLISH_TERMS["minigame.arrowKeysToMove"],
   "minigame.comingSoon": ENGLISH_TERMS["minigame.comingSoon"],
   "minigame.completed": ENGLISH_TERMS["minigame.completed"],
   "minigame.confirm": ENGLISH_TERMS["minigame.confirm"],

--- a/src/lib/i18n/dictionaries/types.ts
+++ b/src/lib/i18n/dictionaries/types.ts
@@ -3492,6 +3492,8 @@ export type GreenhouseKeys =
 export type Minigame =
   | "minigame.playNow"
   | "minigame.chickenRescue"
+  | "minigame.swipeToMove"
+  | "minigame.arrowKeysToMove"
   | "minigame.completed"
   | "minigame.noPrizeAvailable"
   | "minigame.confirm"


### PR DESCRIPTION
# Description

- add on screen instructions when starting the game

Mobile|PC
---|---
![image](https://github.com/sunflower-land/chicken-rescue/assets/107602352/be2a64c5-1d0a-4255-bcaa-14af2f1d4231)|![image](https://github.com/sunflower-land/chicken-rescue/assets/107602352/53555f59-01cb-4953-b264-c25847c30b64)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- start the chicken rescue game

# Checklist:

- [x] Title of the PR is relevant and is prefixed with [FEAT], [CHORE] or [FIX]
- [x] Screenshot if it includes any UI changes
- [x] I have read the contributing guidelines and agree to the T&Cs
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
